### PR TITLE
Allow disabling topology filtering via top_k=0 / max_component=0

### DIFF
--- a/bin/scripts/filter_networking_edges.py
+++ b/bin/scripts/filter_networking_edges.py
@@ -26,8 +26,11 @@ def main():
     if G == None:
         exit(0)
 
-    molecular_network_filtering_library.filter_top_k(G, top_k_val)
-    molecular_network_filtering_library.filter_component(G, max_component_size)
+    # 0 disables that stage of topology filtering; the graph is still re-output.
+    if top_k_val > 0:
+        molecular_network_filtering_library.filter_top_k(G, top_k_val)
+    if max_component_size > 0:
+        molecular_network_filtering_library.filter_component(G, max_component_size)
     molecular_network_filtering_library.output_graph_with_headers(G, args.networking_pairs_results_file_filtered)
 
     #molecular_network_filtering_library.output_graph(G, args.networking_pairs_results_file_filtered_classic_output)

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: classical_networking_workflow
 workflowdescription: This is Classical Molecular Networking for GNPS2
 workflowlongdescription: This is Classical Molecular Networking for GNPS2
-workflowversion: "2026.03.24"
+workflowversion: "2026.06.12"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false


### PR DESCRIPTION
filter_networking_edges.py now skips filter_top_k when top_k_val is 0 and filter_component when max_component_size is 0, re-outputting the full graph. (filter_top_k previously raised KeyError on 0.)