### PR TITLE
Expose force offline annotations as an input option

### DIFF
--- a/nf_workflow.nf
+++ b/nf_workflow.nf
@@ -645,7 +645,9 @@ workflow {
     library_summary_ch = summaryLibrary(libraries_ch)
 
     // Merging all these tsv files from library_summary_ch within nextflow
-    library_summary_merged_ch = library_summary_ch.collectFile(name: 'librarysummary.tsv', keepHeader: true, storeDir: _publishdir + "/librarysummary")
+    // Note: intentionally NOT using storeDir here so the merged library summary is kept only in the
+    // work directory (used downstream for annotations) and not published, since it takes a lot of space.
+    library_summary_merged_ch = library_summary_ch.collectFile(name: 'librarysummary.tsv', keepHeader: true)
     library_summary_merged_ch = library_summary_merged_ch.ifEmpty(file("NO_FILE"))
 
     // Getting library annotations

--- a/nf_workflow.nf
+++ b/nf_workflow.nf
@@ -64,6 +64,9 @@ params.library_filter_window = 1
 params.library_analog_search = "0"
 params.library_analog_max_shift = 1999
 
+// Parameters for Interacting with GNPS Libraries
+params.forceoffline = "Yes" // Yes or No, Yes avoids a bunch of API calls to GNPS and speeds up the workflow
+
 // Workflow Boiler Plate
 params.OMETALINKING_YAML = "flow_filelinking.yaml"
 params.OMETAPARAM_YAML = "job_parameters.yaml"
@@ -646,8 +649,7 @@ workflow {
     library_summary_merged_ch = library_summary_merged_ch.ifEmpty(file("NO_FILE"))
 
     // Getting library annotations
-    force_offline = "No" // This can be set to Yes to avoid any online queries to GNPS, which is useful for testing or if you have a local copy of the GNPS library
-    gnps_library_results_ch = librarygetGNPSAnnotations(merged_results_ch, library_summary_merged_ch, "1", "0", force_offline)
+    gnps_library_results_ch = librarygetGNPSAnnotations(merged_results_ch, library_summary_merged_ch, "1", "0", params.forceoffline)
     gnps_library_results_ch = gnps_library_results_ch.ifEmpty(file("NO_FILE"))
 
     // Networking

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: classical_networking_workflow
 workflowdescription: This is Classical Molecular Networking for GNPS2
 workflowlongdescription: This is Classical Molecular Networking for GNPS2
-workflowversion: "2026.06.12"
+workflowversion: "2026.07.08"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false
@@ -293,6 +293,16 @@ parameterlist:
       nf_paramname: library_topk
       formplaceholder: Enter the topk
       formvalue: "1"
+
+    - displayname: Force Offline Annotations (speeds up workflow)
+      paramtype: select
+      nf_paramname: forceoffline
+      formvalue: "Yes"
+      options:
+        - value: "Yes"
+          display: "Yes"
+        - value: "No"
+          display: "No"
 
     
 


### PR DESCRIPTION
Mirror the Library Search Workflow: add a params.forceoffline knob (default "Yes") and a Yes/No select in workflowinput.yaml, threading it into librarygetGNPSAnnotations instead of the hardcoded "No". Force offline avoids per-hit GNPS API calls and speeds up the workflow.

Bump workflowversion to 2026.07.08.